### PR TITLE
Use default timeout for Optimize snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
   h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
   (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-  })(window,document.documentElement,'async-hide','dataLayer',2000,
+  })(window,document.documentElement,'async-hide','dataLayer',4000,
   {'GTM-N7SG829':true});</script>
 
   <!-- GPI Google Tag Manager -->


### PR DESCRIPTION
Switch to the suggested by Google timeout value, since the snippet still expires in low speed connections.