### PR TITLE
PLANET-5491: Run accessibility tests on landing page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,25 @@ jobs:
       - run: make -C deploy checkout
       - run: make -C deploy lint
 
+  test-a11y:
+    <<: *defaults
+    environment:
+      GOOGLE_PROJECT_ID: planet4-production
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - run: make -C deploy checkout
+      - run: make -C deploy build
+      - run: make -C deploy test-a11y
+      - run:
+          name: Analyse test results
+          command: |
+            errors=$(jq '.["issues"] | unique_by(.["type"]) | map(select(.["type"] == "error")) | .[]' ~/app/deploy/docker/source/pa11y/report.json)
+            if [ ! -z "${errors}" ]; then echo "Errors found, see report in artifacts." && exit 1; else echo "No errors, report available in artifacts."; fi
+      - store_artifacts:
+          path: ~/app/deploy/docker/source/pa11y
+
   deploy-dev:
     <<: *defaults
     environment:
@@ -30,9 +49,12 @@ jobs:
       - run: docker-login.sh
       - run: make -C deploy checkout
       - run: make -C deploy commit
-      - run: make -C deploy build
+      - run: make -C deploy docker-build
+      - run: make -C deploy test-a11y
       - run: make -C deploy docker-push
       - run: make -C deploy dev
+      - store_artifacts:
+          path: ~/app/deploy/docker/source/
 
   deploy-tag:
     <<: *defaults
@@ -46,11 +68,14 @@ jobs:
       - run: docker-login.sh
       - run: make -C deploy checkout
       - run: make -C deploy tag
-      - run: make -C deploy build
+      - run: make -C deploy docker-build
+      - run: make -C deploy test-a11y
       - run: make -C deploy docker-push
       - run:
           command: make -C deploy prod
           no_output_timeout: 30m
+      - store_artifacts:
+          path: ~/app/deploy/docker/source/
 
 workflows:
   version: 2
@@ -63,6 +88,14 @@ workflows:
               ignore: master
             tags:
               ignore: /.*/
+      - test-a11y:
+          context: org-global
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
+
   dev:
     jobs:
       - deploy-dev:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tests/
 node_modules/
 dist/
+pa11y/

--- a/.pa11y
+++ b/.pa11y
@@ -1,0 +1,18 @@
+{
+    "defaults": {
+        "timeout": 30000,
+        "viewport": {
+            "width": 1200,
+            "height": 800
+        },
+        "chromeLaunchConfig": {
+            "ignoreHTTPSErrors": true,
+            "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+        },
+        "includeWarnings": true,
+        "includeNotices": true
+    },
+    "urls": [
+        "http://localhost:9000"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ On first run fetch the countries data:
 
     gulp countries
 
-Build the style guide:
+Build the landing page:
 
     gulp build
 
@@ -28,13 +28,13 @@ Run the local webserver:
 
     gulp
 
-Browse to [localhost:8080](http://localhost:9000).
+Browse to [localhost:9000](http://localhost:9000).
 
 ## Test
 
 To run linters:
 
-    gulp test
+    gulp lint
 
 For visual regression tests, start by generating reference screenshots:
 
@@ -45,6 +45,13 @@ At any time you can create test screenshots:
     gulp backstop_test
 
 Once this is finished a report will be launched in your browser in order to inspect the visual diff.
+
+To run accessibility test:
+
+    gulp test
+
+Results are available in `pa11y/report.html` (open in your browser) and `pa11y/report.json` (open with `jq`).  
+Configuration is in `.pa11y`.
 
 ## Deployment
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -29,6 +29,9 @@ BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD | sed 's/$(SED_MATCH)/-/g
 BUILD_TAG ?= $(shell git tag -l --points-at HEAD | tail -n1 | sed 's/$(SED_MATCH)/-/g')
 endif
 
+# A11y test config
+PA11Y_DIR = pa11y
+PA11Y_CONF = .pa11y
 
 
 # If BUILD_TAG is blank there's no tag on this commit
@@ -43,7 +46,7 @@ endif
 REVISION_TAG = $(shell git rev-parse --short HEAD)
 
 
-test:
+lint:
 	yamllint values.yml
 	yamllint env/dev/values.yml
 	yamllint env/prod/values.yml
@@ -67,13 +70,31 @@ docker/public:
 	sudo npm install -g gulp-cli
 	cd docker/source ; git submodule init
 	cd docker/source ; git submodule update
+	cd docker/source ; gulp lint
 	cd docker/source ; gulp countries
 	cd docker/source ; gulp build
-	mv docker/source/dist docker/public
+	cp -R docker/source/dist docker/public
 
-lint: test docker/public
+build: lint docker/public
 
-build: test pull docker/public echo-build
+.PHONY: test-a11y
+test-a11y: install-pa11y
+	cd docker/source ; gulp & sleep 3
+	cd docker/source ; gulp test
+
+.PHONY: install-pa11y
+install-pa11y: install-puppeteer-deps
+	npm install pa11y-ci pa11y-ci-reporter-html
+
+.PHONY: install-puppeteer-deps
+install-puppeteer-deps:
+	sudo apt-get update && sudo apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+	libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+	libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+	libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+	ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+docker-build: lint pull docker/public echo-build
 	docker build --tag=greenpeaceinternational/p4-landing-page:$(BUILD_NUM) docker
 
 docker-push:
@@ -90,7 +111,7 @@ prod-config:
 echo-build:
 	$(info BUILD_NUM is [${BUILD_NUM}])
 
-dev: test dev-config
+dev: lint dev-config
 	helm init --client-only
 	helm repo add p4 https://planet4-helm-charts.storage.googleapis.com && \
 	helm repo update
@@ -102,7 +123,7 @@ dev: test dev-config
 		--set openresty.geoip.accountid=$(GEOIP_ACCOUNTID) \
 		--set openresty.geoip.license=$(GEOIP_LICENSE)
 
-prod: test prod-config
+prod: lint prod-config
 	helm init --client-only
 	helm repo add p4 https://planet4-helm-charts.storage.googleapis.com && \
 	helm repo update

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,6 +148,23 @@ function backstop_test(done) {
   done();
 }
 
+function a11y_test(done) {
+  const pa11y = require('pa11y');
+  const report_dest = './pa11y';
+  const url = 'http://localhost:9000';
+
+  pa11y(url).then(async results => {
+    const reporter = require('pa11y-reporter-html');
+    const html = await reporter.results(results, url);
+    if(!fs.existsSync(report_dest)) {
+      fs.mkdirSync(report_dest);
+    }
+    fs.writeFileSync(report_dest + '/report.html', html);
+    fs.writeFileSync(report_dest + '/report.json', JSON.stringify(results));
+  });
+  done();
+}
+
 function serve(done) {
   connect.server({
     root: './dist',
@@ -159,7 +176,8 @@ function serve(done) {
 
 exports.backstop_reference = backstop_reference;
 exports.backstop_test = backstop_test;
-exports.test = gulp.parallel(lint_css, lint_js);
+exports.lint = gulp.parallel(lint_css, lint_js);
 exports.countries = gulp.series(countries, urls, inject);
 exports.build = gulp.series(lint_css, style_sass, uglify, img, files);
+exports.test = gulp.series(a11y_test);
 exports.default = gulp.series(watch, serve);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,6 +1168,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axe-core": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "dev": true
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -1353,6 +1359,17 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bfj": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-4.2.4.tgz",
+      "integrity": "sha1-hfeyNoPCr9wVhgOEotHD+sgO0zo=",
+      "dev": true,
+      "requires": {
+        "check-types": "^7.3.0",
+        "hoopy": "^0.1.2",
+        "tryer": "^1.0.0"
       }
     },
     "bignumber.js": {
@@ -1655,6 +1672,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "check-types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
+      "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==",
+      "dev": true
     },
     "chokidar": {
       "version": "2.1.6",
@@ -4519,6 +4542,33 @@
         }
       }
     },
+    "hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -4526,6 +4576,12 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -4536,6 +4592,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.0.0.tgz",
       "integrity": "sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA=="
+    },
+    "html_codesniffer": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/html_codesniffer/-/html_codesniffer-2.5.1.tgz",
+      "integrity": "sha512-vcz0yAaX/OaV6sdNHuT9alBOKkSxYb8h5Yq26dUqgi7XmCgGUSa7U9PiY1PBXQFMjKv1wVPs5/QzHlGuxPDUGg==",
+      "dev": true
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -4748,6 +4810,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "dev": true
+    },
+    "is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
       "dev": true
     },
     "is-absolute": {
@@ -5866,6 +5934,16 @@
         }
       }
     },
+    "node.extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-2.0.2.tgz",
+      "integrity": "sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "is": "^3.2.1"
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -6129,6 +6207,12 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -6151,10 +6235,96 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
+    "pa11y": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-5.3.0.tgz",
+      "integrity": "sha512-g1cVpmRQQXClTZYbx4JC+FqCu6AfM9K3px2TPb2NY9JrorxYiInOKQCa9eF6URjY//bDkQmkn65rTWmbwTC07A==",
+      "dev": true,
+      "requires": {
+        "commander": "^3.0.2",
+        "node.extend": "^2.0.2",
+        "p-timeout": "^2.0.1",
+        "pa11y-reporter-cli": "^1.0.1",
+        "pa11y-reporter-csv": "^1.0.0",
+        "pa11y-reporter-json": "^1.0.0",
+        "pa11y-runner-axe": "^1.0.1",
+        "pa11y-runner-htmlcs": "^1.2.0",
+        "puppeteer": "^1.13.0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+          "dev": true
+        }
+      }
+    },
+    "pa11y-reporter-cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-cli/-/pa11y-reporter-cli-1.0.1.tgz",
+      "integrity": "sha512-k+XPl5pBU2R1J6iagGv/GpN/dP7z2cX9WXqO0ALpBwHlHN3ZSukcHCOhuLMmkOZNvufwsvobaF5mnaZxT70YyA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.1.0"
+      }
+    },
+    "pa11y-reporter-csv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-csv/-/pa11y-reporter-csv-1.0.0.tgz",
+      "integrity": "sha512-S2gFgbAvONBzAVsVbF8zsYabszrzj7SKhQxrEbw19zF0OFI8wCWn8dFywujYYkg674rmyjweSxSdD+kHTcx4qA==",
+      "dev": true
+    },
+    "pa11y-reporter-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-html/-/pa11y-reporter-html-2.0.0.tgz",
+      "integrity": "sha512-IuPxfb0P+uIAyoLSTkGyAv2jUHsN/iNEo3SHj0bUKQDRd84+tvEH3sHaO/ydIaECWcRYVGOADBNwMud6uQ5PNQ==",
+      "dev": true,
+      "requires": {
+        "hogan.js": "^3.0.2"
+      }
+    },
+    "pa11y-reporter-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pa11y-reporter-json/-/pa11y-reporter-json-1.0.0.tgz",
+      "integrity": "sha512-EdLrzh1hyZ8DudCSSrcakgtsHDiSsYNsWLSoEAo1JnFTIK8hYpD7vL+xgd0u+LXDxz9wLLFnckdubpklaRpl/w==",
+      "dev": true,
+      "requires": {
+        "bfj": "^4.2.3"
+      }
+    },
+    "pa11y-runner-axe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pa11y-runner-axe/-/pa11y-runner-axe-1.0.2.tgz",
+      "integrity": "sha512-HMw5kQZz16vS5Bhe067esgeuULNzFYP4ixOFAHxOurwGDptlyc2OqH6zfUuK4szB9tbgb5F23v3qz9hCbkGRpw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.5.1"
+      }
+    },
+    "pa11y-runner-htmlcs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pa11y-runner-htmlcs/-/pa11y-runner-htmlcs-1.2.0.tgz",
+      "integrity": "sha512-uf0wEsoeRfyALXVcZeDadV7ot7pE6JZ3EZwbspwmyXW30ahjCClAfE/FtaNo1y2Mlxx5J9ui1sW2YzhHXocV5g==",
+      "dev": true,
+      "requires": {
+        "html_codesniffer": "^2.4.1"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -8507,6 +8677,12 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
+      "dev": true
     },
     "tslib": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "Greenpeace International",
   "license": "GPLv3",
   "devDependencies": {
-    "backstopjs": "^4.0.6"
+    "backstopjs": "^4.0.6",
+    "pa11y": "^5.3.0",
+    "pa11y-reporter-html": "^2.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.4.5",


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5491  
Ref: https://jira.greenpeace.org/browse/PLANET-5275

Runs pa11y on the landing page.  

### CI 

I wasn't exactly sure how to organize this, so:
- on a feature branch, the [CI fails the `test-a11y` job](https://app.circleci.com/pipelines/github/greenpeace/planet4-landing-page/129/workflows/d7d97acc-ef9c-4fb0-bed1-1c28dbff700f) if errors are found
- on deploy, it should just produce a report

Report is available in [html in CI artifacts](https://176-176940738-gh.circle-artifacts.com/0/%7E/app/deploy/docker/source/pa11y/report.html) 

### Local

Command `gulp test` will run the accessibility test.  
`npm` will install pa11y dependencies in development

### Changes / renaming

A few names seemed strange, so I took the liberty to change those in the Makefile:
- `test` became `lint` (it only lints yaml)
- `lint` became `build` (it calls lint and then builds the sources)
- `build` became `docker-build` (it literaly runs docker build)

and moved gulp recipes, `test` to `lint`, and used a11y test as `test`.