### PR TITLE
PLANET-5491: Fix artifact storage in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run: make -C deploy docker-push
       - run: make -C deploy dev
       - store_artifacts:
-          path: ~/app/deploy/docker/source/
+          path: ~/app/deploy/docker/source/pa11y
 
   deploy-tag:
     <<: *defaults
@@ -75,7 +75,7 @@ jobs:
           command: make -C deploy prod
           no_output_timeout: 30m
       - store_artifacts:
-          path: ~/app/deploy/docker/source/
+          path: ~/app/deploy/docker/source/pa11y
 
 workflows:
   version: 2


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-5491 
Ref: https://jira.greenpeace.org/browse/PLANET-5275  

Fixes error on https://github.com/greenpeace/planet4-landing-page/pull/19

:point_right:  Somebody :point_left: mistakenly copied the [whole source folder](https://app.circleci.com/pipelines/github/greenpeace/planet4-landing-page/133/workflows/4e41b135-0d17-4604-a5cd-23283b39dc22/jobs/187) in artifacts instead of just the pa11y report. The source folder contains a node_modules folder. This is a good way to make the universe collapse. Don't do this.

## Fix

Changed the folder to store in artifacts so that it only takes `pa11y` folder.