### PR TITLE
PLANET-7376 Change 404 header color to white

### DIFF
--- a/static/scss/base/_404.scss
+++ b/static/scss/base/_404.scss
@@ -1,3 +1,7 @@
+:root {
+  --color-text-heading: var(--white);
+}
+
 body {
   background-color: var(--white);
 }


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7376

---

This address readability issues for this text on top of the bg image. The change has been verified by the design team.

### Testing

1. Running it locally
2. Browse to http://localhost:9000/404.html
3. All text should be white