### PR TITLE
PLANET-7980: Improve alphabetical headings to screen readers

### DIFF
--- a/static/js/country_list.js
+++ b/static/js/country_list.js
@@ -8,8 +8,8 @@ Object.entries(data).forEach(letter => {
   if ( '0' === letter[0] ) {
     international_html += `<a class="international" href="${letter[1][0].url}">${letter[1][0].name}</a>`;
   } else {
-    sublist_html += `<li class="country-list-item"><h3 class="country-group-letter">${letter[0]}</h3>
-      <ul class="countries_sublist">`;
+    sublist_html += `<li class="country-list-item"><span class="country-group-letter">${letter[0]}</span>
+      <ul class="countries_sublist" aria-label="Sites starting with the letter ${letter[0]}.">`;
     letter[1].forEach(country => {
       const lang = country.lang;
       lang.forEach(item => {


### PR DESCRIPTION
# Summary
Make countries list more descriptive for screen readers

Ref: https://greenpeace-planet4.atlassian.net/browse/PLANET-7980

## Testing

You can inspect the code and/or use a screen reader. 
Here is the full script to run it locally from scratch:

```bash
nvm use 16 \
&& git clone git@github.com:greenpeace/planet4-landing-page.git \
&& cd planet4-landing-page \
&& git submodule update --init --recursive \
&& npm install \
&& gulp countries \
&& gulp build \
&& gulp
```
